### PR TITLE
Allow magento/framework to match more recent Magento

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
-    "magento/framework": "~100.0.0"
+    "magento/framework": "~100.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "sectionio/metrics",
   "description": "Retrieve site metrics for your Section.io account.",
   "type": "magento2-module",
-  "version": "101.2.0",
+  "version": "101.2.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
More recent Magento contains magento/framework[100.1.2]
Existing require declaration won't match this.
