### PR TITLE
Extension supports Varnish 5+  

### DIFF
--- a/Console/Command/UpdateVclCommand.php
+++ b/Console/Command/UpdateVclCommand.php
@@ -23,21 +23,26 @@ class UpdateVclCommand extends Command
     protected $state;
     /** @var \Magento\PageCache\Model\Config\PageCache $pageCacheConfig */
     protected $pageCacheConfig;
+    /** @var \Sectionio\Metrics\Helper\Data $helper */
+    protected $helper;
 
     /**
      * @param \Sectionio\Metrics\Helper\Aperture $aperture
      * @param \Sectionio\Metrics\Helper\State $state
+     * @param \Sectionio\Metrics\Helper\Data $helper
      * @param \Magento\PageCache\Model\Config $pageCacheConfig
      */
     public function __construct(
         \Sectionio\Metrics\Helper\Aperture $aperture,
         \Sectionio\Metrics\Helper\State $state,
+        \Sectionio\Metrics\Helper\Data $helper,
         \Magento\PageCache\Model\Config $pageCacheConfig
     ) {
         parent::__construct();
         $this->aperture = $aperture;
         $this->state = $state;
         $this->pageCacheConfig = $pageCacheConfig;
+        $this->helper = $helper;
     }
 
     /**
@@ -60,6 +65,8 @@ class UpdateVclCommand extends Command
         $application_id = $this->state->getApplicationId();
         $environment_name = $this->state->getEnvironmentName();
         $proxy_name = $this->state->getProxyName();
+        /** @var string $proxy_image*/
+        $proxy_image = $this->helper->getProxyImage($account_id, $application_id);
 
         if (!$account_id) {
             throw new \Exception('account_id has not been set, please run sectionio:setup');
@@ -77,8 +84,13 @@ class UpdateVclCommand extends Command
             throw new \Exception('proxy_name has not been set, please run sectionio:setup');
         }
 
-        /** Extract the generated Varnish 4 VCL code */
-        $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
+        /** Extract the generated VCL code appropriate for their version*/
+        if (strpos($proxy_image, "4" !== false)){
+            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
+        } else {
+            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);
+        }
+
         $result = $this->aperture->updateProxyConfiguration($account_id, $application_id, $environment_name, $proxy_name, $vcl, 'MagentoTurpentine');
 
         if ($result['http_code'] == 200) {

--- a/Console/Command/UpdateVclCommand.php
+++ b/Console/Command/UpdateVclCommand.php
@@ -66,7 +66,7 @@ class UpdateVclCommand extends Command
         $environment_name = $this->state->getEnvironmentName();
         $proxy_name = $this->state->getProxyName();
         /** @var string $proxy_image*/
-        $proxy_image = $this->helper->getProxyImage($account_id, $application_id);
+        $proxy_version = $this->helper->getProxyVersion($account_id, $application_id);
 
         if (!$account_id) {
             throw new \Exception('account_id has not been set, please run sectionio:setup');
@@ -84,8 +84,10 @@ class UpdateVclCommand extends Command
             throw new \Exception('proxy_name has not been set, please run sectionio:setup');
         }
 
+        $major_release = $this->helper->getMajorRelease($proxy_version);
+
         /** Extract the generated VCL code appropriate for their version*/
-        if (strpos($proxy_image, "4" !== false)){
+        if ($major_release == "4" ){
             $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
         } else {
             $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);

--- a/Console/Command/UpdateVclCommand.php
+++ b/Console/Command/UpdateVclCommand.php
@@ -86,12 +86,9 @@ class UpdateVclCommand extends Command
 
         $major_release = $this->helper->getMajorRelease($proxy_version);
 
+
         /** Extract the generated VCL code appropriate for their version*/
-        if ($major_release == "4" ){
-            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
-        } else {
-            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);
-        }
+        $vcl = $this->helper->getCorrectVCL($this->pageCacheConfig, $major_release);
 
         $result = $this->aperture->updateProxyConfiguration($account_id, $application_id, $environment_name, $proxy_name, $vcl, 'MagentoTurpentine');
 

--- a/Controller/Adminhtml/Report/Save.php
+++ b/Controller/Adminhtml/Report/Save.php
@@ -203,10 +203,11 @@ class Save extends Action
         /** @var string $environment_name */
         $environment_name = $this->state->getEnvironmentName();
         /** @var string $proxy_image*/
-        $proxy_image = $this->helper->getProxyImage($account_id, $application_id);
+        $proxy_version = $this->helper->getProxyVersion($account_id, $application_id);
 
+        $major_release = $this->helper->getMajorRelease($proxy_version);
         /** Extract the generated VCL code appropriate for their version*/
-        if (strpos($proxy_image, "4" !== false)){
+        if ($major_release == "4") {
             $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
         } else {
             $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);

--- a/Controller/Adminhtml/Report/Save.php
+++ b/Controller/Adminhtml/Report/Save.php
@@ -202,9 +202,16 @@ class Save extends Action
         $application_id = $this->state->getApplicationId();
         /** @var string $environment_name */
         $environment_name = $this->state->getEnvironmentName();
+        /** @var string $proxy_image*/
+        $proxy_image = $this->helper->getProxyImage($account_id, $application_id);
 
-        /** Extract the generated Varnish 4 VCL code */
-        $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
+        /** Extract the generated VCL code appropriate for their version*/
+        if (strpos($proxy_image, "4" !== false)){
+            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
+        } else {
+            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);
+        }
+
         $result = $this->aperture->updateProxyConfiguration($account_id, $application_id, $environment_name, 'varnish', $vcl, 'MagentoTurpentine');
 
         if ($result['http_code'] == 200) {

--- a/Controller/Adminhtml/Report/Save.php
+++ b/Controller/Adminhtml/Report/Save.php
@@ -206,12 +206,9 @@ class Save extends Action
         $proxy_version = $this->helper->getProxyVersion($account_id, $application_id);
 
         $major_release = $this->helper->getMajorRelease($proxy_version);
+
         /** Extract the generated VCL code appropriate for their version*/
-        if ($major_release == "4") {
-            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
-        } else {
-            $vcl = $this->pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);
-        }
+        $vcl = $this->helper->getCorrectVCL($this->pageCacheConfig, $major_release);
 
         $result = $this->aperture->updateProxyConfiguration($account_id, $application_id, $environment_name, 'varnish', $vcl, 'MagentoTurpentine');
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -594,7 +594,7 @@ class Data extends AbstractHelper
         /** return response as an associative array */
         $response = json_decode($curl_response['body_content'], true);
 
-        /** find object with name=varnish, grab the image  */
+        /** find element with name=varnish, grab the image  */
         $image;
         foreach($response as $proxy){
             if ($proxy['name'] == 'varnish') { 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -631,7 +631,7 @@ class Data extends AbstractHelper
      * 
      * @return string
      */
-    public function getCorrectVCL($pageCacheConfig, $majorRelease) 
+    public function getCorrectVCL($pageCacheConfig, $major_release) 
     {
         if ($major_release == "4") {
             return $pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -609,6 +609,6 @@ class Data extends AbstractHelper
     /** takes a full version like "5.2.1" and returns the major release (5) */
     public function getMajorRelease($full_release)
     {
-        return explode(".", $full_release)[1];
+        return explode(".", $full_release)[0];
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -580,8 +580,15 @@ class Data extends AbstractHelper
             $applicationFactory->save();
         }
     }
-
-    /** get complete proxy image version for a given environment from aperture. */
+    
+    /**
+     * get complete proxy image version for a given environment from aperture.
+     *
+     * @param int $account_id
+     * @param int $application_id
+     *
+     * @return string
+     */
     public function getProxyVersion($account_id, $application_id)
     {
         /**generateApertureUrl takes an associative array */
@@ -605,8 +612,13 @@ class Data extends AbstractHelper
         /** returns only the version ie "5.2.1" */
         return explode(":", $image)[1];
     }
-
-    /** takes a full version like "5.2.1" and returns the major release (5) */
+    
+    /**
+     * Takes a full version like "5.2.1" and returns the major release (5)
+     * @param string $full_release
+     * 
+     * @return string
+     */
     public function getMajorRelease($full_release)
     {
         return explode(".", $full_release)[0];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -593,8 +593,8 @@ class Data extends AbstractHelper
         $curl_response = $this->performCurl($url);
         /** return response as an associative array */
         $response = json_decode($curl_response['body_content'], true);
-        /** find object with name=varnish, grab the image  */
 
+        /** find object with name=varnish, grab the image  */
         $image;
         foreach($response as $proxy){
             if ($proxy['name'] == 'varnish') { 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -581,7 +581,8 @@ class Data extends AbstractHelper
         }
     }
 
-    public function getProxyImage($account_id, $application_id)
+    /** get complete proxy image version for a given environment from aperture. */
+    public function getProxyVersion($account_id, $application_id)
     {
         /**generateApertureUrl takes an associative array */
         $parameters = array("accountId"=>$account_id, "applicationId"=>$application_id, "environmentName"=>"Production");
@@ -601,6 +602,13 @@ class Data extends AbstractHelper
                 $image = $proxy['image'];
             }
         }
-        return explode(".", $image)[0];
+        /** returns only the version ie "5.2.1" */
+        return explode(":", $image)[1];
+    }
+
+    /** takes a full version like "5.2.1" and returns the major release (5) */
+    public function getMajorRelease($full_release)
+    {
+        return explode(".", $full_release)[1];
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -623,4 +623,20 @@ class Data extends AbstractHelper
     {
         return explode(".", $full_release)[0];
     }
+
+    /**
+     * Takes in the pageCacheConfig object and a major release and returns the correct vcl
+     * @param object $pageCacheConfig
+     * @param string $full_release
+     * 
+     * @return string
+     */
+    public function getCorrectVCL($pageCacheConfig, $majorRelease) 
+    {
+        if ($major_release == "4") {
+            return $pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_4_CONFIGURATION_PATH);
+        } else {
+            return $pageCacheConfig->getVclFile(\Magento\PageCache\Model\Config::VARNISH_5_CONFIGURATION_PATH);
+        }
+    }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -580,4 +580,27 @@ class Data extends AbstractHelper
             $applicationFactory->save();
         }
     }
+
+    public function getProxyImage($account_id, $application_id)
+    {
+        /**generateApertureUrl takes an associative array */
+        $parameters = array("accountId"=>$account_id, "applicationId"=>$application_id, "environmentName"=>"Production");
+
+        /** build the account url */
+        $partial_url = $this->generateApertureUrl($parameters);
+        $url = $partial_url . "/stack";
+
+        $curl_response = $this->performCurl($url);
+        /** return response as an associative array */
+        $response = json_decode($curl_response['body_content'], true);
+        /** find object with name=varnish, grab the image  */
+
+        $image;
+        foreach($response as $proxy){
+            if ($proxy['name'] == 'varnish') { 
+                $image = $proxy['image'];
+            }
+        }
+        return explode(".", $image)[0];
+    }
 }

--- a/Helper/State.php
+++ b/Helper/State.php
@@ -96,4 +96,9 @@ class State extends AbstractHelper
     {
         return 'varnish';
     }
+
+    public function getProxyImage()
+    {
+        
+    }
 }

--- a/Helper/State.php
+++ b/Helper/State.php
@@ -96,9 +96,4 @@ class State extends AbstractHelper
     {
         return 'varnish';
     }
-
-    public function getProxyImage()
-    {
-        
-    }
 }


### PR DESCRIPTION
Adds logic to deliver the appropriate magento vcl based upon the varnish image of the account making the request. Tested with Varnish 4, 5, and 6 instances alongside other proxies. 