### PR TITLE
Set the AreaCode for the app state created by the ObjectManager

### DIFF
--- a/Console/Command/SetupCommand.php
+++ b/Console/Command/SetupCommand.php
@@ -116,7 +116,18 @@ class SetupCommand extends Command
             throw new \InvalidArgumentException('Argument ' . self::APPLICATION_ID_ARGUMENT . ' must be your application id number.');
         }
 
-        $this->state->setAreaCode('adminhtml');
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+
+        // Attempt to set the AreaCode for the App State created by the ObjectManager
+        // In Magento Commerce 2.2.3 the \Magento\Framework\App\State object returned by the ObjectManager is a
+        // different instance to the one injected by DI
+        $appStateOm = \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\App\State::class);
+        try {
+            $appStateOm->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+        } catch (\Exception $e) {
+            //AreaCode is already set, move on
+        }
+
         $settingsFactory = $this->settingsFactory->create()->getCollection()->getFirstItem();
 
         // Load existing model if available


### PR DESCRIPTION
Magento Commerce 2.2.3 was throwing errors due to the AreaCode not being set when the SidResolver called into app state to get the area code.

The app state object being inserted by the DI system is null and the instance created by the ObjectManager is a different instance to the one we get injected into our SetupCommand class.

See https://github.com/magento/magento2/blob/2.2.3/lib/internal/Magento/Framework/Session/SidResolver.php#L85