### PR TITLE
removed module-page-cache explicit dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
   ],
   "require": {
     "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
-    "magento/framework": "~102.0.3|| ~103.0|| ~104.0",
-    "magento/module-page-cache": "~100.3.3"
+    "magento/framework": "~102.0.3||~103.0||~104.0"
   },
   "autoload": {
     "files": [ "registration.php" ],


### PR DESCRIPTION
the module-page-cache explicit dependencies were introduced to make the extension backward compatible. I since removed the older versions of magento-framework to reduce complexity. This PR has now removed the explicit dependency for module-page-cache. 

I tested this install manually on magento2.section-demo.net using composer.json

also updated product catalog and cache bans working in [Kibana](https://aperture.section.io/account/1855/application/7072/kibana/#/discover?_g=()&_a=(columns:!(params.banExpression,useragent,userEmail),filters:!((meta:(disabled:!f,index:'account1855-app7072-*',key:_type,negate:!f,value:api-audit-log),query:(match:(_type:(query:api-audit-log,type:phrase))))),index:'account1855-app7072-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc)))

This version also passes the Magento Marketplace automated tests. 